### PR TITLE
Update the `base_ami` filter to use the `base_ami_name_filter` variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "base_ami" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+    values = [var.base_ami_name_filter]
   }
 
   filter {

--- a/variables.tf
+++ b/variables.tf
@@ -17,8 +17,8 @@ variable "conc_version" {
 }
 
 variable "base_ami_name_filter" {
-  default     = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
-  description = "Name filter for the base ami for Concourse machines. Defaults to Ubuntu 20.04 LTS. View the AWS docs for more info."
+  default     = ["amzn2-ami-hvm-*-x86_64-ebs"]
+  description = "Name filter for the base ami for Concourse machines. Defaults to Amazon Linux 2 AMI (HVM). View the AWS docs for more info."
 }
 
 variable "concdb_host" {


### PR DESCRIPTION
- updated the `base_ami` filter to use the already existing `base_ami_name_filter` variable
- updated the default value to match the previously hard-coded value